### PR TITLE
feat: add newspack_blocks support

### DIFF
--- a/newspack-supporters.php
+++ b/newspack-supporters.php
@@ -46,7 +46,7 @@ class Newspack_Supporters {
 	 * Register post type and taxonomy.
 	 */
 	public static function register() {
-		register_post_type( 
+		register_post_type(
 			self::POST_TYPE,
 			[
 				'labels'              => [
@@ -68,8 +68,8 @@ class Newspack_Supporters {
 				'show_in_menu'        => true,
 				'show_in_nav_menus'   => false,
 				'show_in_admin_bar'   => false,
-				'show_in_rest'        => false,
-				'supports'            => [ 'title', 'thumbnail' ],
+				'show_in_rest'        => true,
+				'supports'            => [ 'title', 'thumbnail', 'newspack_blocks' ],
 			]
 		);
 


### PR DESCRIPTION
Adds `newspack_blocks` support so that Supporters can be inserted into Post Carousel and Homepage Posts blocks. Also shows the post's URL as the link in the carousel, if set, instead of the permalink (since Supporters don't have a singular view).

To test:

1. Ensure your Blocks repo has https://github.com/Automattic/newspack-blocks/pull/750 checked out
2. Create a Post Carousel and Homepage Posts block
3. Expand Post Types and confirm that Supporters is available as an option
4. Enable Supporters, confirm that they're shown both in the preview and on the front-end, both AMP and non-AMP